### PR TITLE
Non-enumerable, tests string 'false'

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,9 @@
-Object.prototype.isTrue = function(){return this.valueOf()?true:false}
-
-
+Object.defineProperty(Object.prototype, "isTrue", {
+    get: function () {
+        var value = this.valueOf();
+        if (typeof value == 'string')
+            return !!value.length && !(/^(false|0)$/i).test(value);
+        else
+            return value ? true : false;
+    }
+});


### PR DESCRIPTION
Extending directly from Object.prototype made the new property
enumerable and would be iterated over on for in loops. Using
Object.defineProperty hides the new property from iterators.
Also checks for the string value 'false', and returns true for any value
not equal to 'false' (case-insensitive) or '0'.